### PR TITLE
Respect numArgs in specific optimization.

### DIFF
--- a/src/main/java/com/laytonsmith/core/MethodScriptCompiler.java
+++ b/src/main/java/com/laytonsmith/core/MethodScriptCompiler.java
@@ -1856,7 +1856,15 @@ public final class MethodScriptCompiler {
 				try {
 					Construct result;
 					if (options.contains(OptimizationOption.CONSTANT_OFFLINE)) {
-						result = func.exec(tree.getData().getTarget(), null, constructs);
+						List<Integer> numArgsList = Arrays.asList(func.numArgs());
+						if (!numArgsList.contains(Integer.MAX_VALUE) &&
+								!numArgsList.contains(tree.getChildren().size())) {
+							compilerErrors.add(new ConfigCompileException("Incorrect number of arguments passed to "
+									+ tree.getData().val(), tree.getData().getTarget()));
+							result = null;
+						} else {
+							result = func.exec(tree.getData().getTarget(), null, constructs);
+						}
 					} else {
 						result = ((Optimizable) func).optimize(tree.getData().getTarget(), constructs);
 					}

--- a/src/test/java/com/laytonsmith/testing/StaticTest.java
+++ b/src/test/java/com/laytonsmith/testing/StaticTest.java
@@ -72,7 +72,6 @@ import com.laytonsmith.core.functions.BasicLogic.equals;
 import com.laytonsmith.core.functions.Exceptions;
 import com.laytonsmith.core.functions.Function;
 import com.laytonsmith.core.functions.FunctionBase;
-import com.laytonsmith.core.functions.Scoreboards;
 import org.mockito.Mockito;
 
 import java.io.File;
@@ -198,6 +197,7 @@ public class StaticTest {
 
     /**
      * Checks to see if the documentation follows the specified format
+	 * @param f
      */
     public static void TestDocs(Function f) {
         //TODO
@@ -302,6 +302,7 @@ public class StaticTest {
 
     /**
      * Gets the value out of s construct, ignoring information like line numbers.
+	 * @param c
      * @return
      */
     public static Object Val(Construct c) {
@@ -387,9 +388,7 @@ public class StaticTest {
 
     public static List<Token> tokens(Token... array) {
         List<Token> tokens = new ArrayList<Token>();
-        for (Token t : array) {
-            tokens.add(t);
-        }
+		tokens.addAll(Arrays.asList(array));
         return tokens;
     }
 
@@ -561,6 +560,7 @@ public class StaticTest {
 
     /**
      * Creates an entire fake server environment, adding players and everything.
+	 * @return The fake MCServer
      */
     public static MCServer GetFakeServer(){
         MCServer fakeServer = mock(MCServer.class);
@@ -605,6 +605,7 @@ public class StaticTest {
      * work. Additionally, adds the fakePlayer to the server, if player based
      * events are to be called, this is the player returned.
      * @param fakePlayer
+	 * @throws java.lang.Exception
      */
     public static void InstallFakeConvertor(MCPlayer fakePlayer) throws Exception{
         InstallFakeServerFrontend();
@@ -923,7 +924,6 @@ public class StaticTest {
                     break;
                 } catch(NoSuchFieldException e){
                     search = search.getSuperclass();
-                    continue;
                 }
             }
             if(f == null){


### PR DESCRIPTION
- Functions with OptimizationOption.CONSTANT_OFFLINE would have their
  exec() method called before checking if the right number of arguments
  was passed to it. This caused errors in core and no compile errors on
  code such as "abs(1,2,3,4,5,6)" while abs() should only take one
  argument.
- Small cleanup (forgotten in last PR, no functional changes).
