### PR TITLE
Fixed an error in core in array_implode.

### DIFF
--- a/src/main/java/com/laytonsmith/core/functions/ArrayHandling.java
+++ b/src/main/java/com/laytonsmith/core/functions/ArrayHandling.java
@@ -1384,11 +1384,11 @@ public class ArrayHandling {
 
 		@Override
 		public Construct exec(Target t, Environment environment, Construct... args) throws ConfigRuntimeException {
-			if (!(args[0] instanceof ArrayAccess)) {
+			if (!(args[0] instanceof CArray)) {
 				throw new CRECastException("Expecting argument 1 to be an array", t);
 			}
 			StringBuilder b = new StringBuilder();
-			ArrayAccess ca = (ArrayAccess) args[0];
+			CArray ca = (CArray) args[0];
 			String glue = " ";
 			if (args.length == 2) {
 				glue = args[1].val();


### PR DESCRIPTION
array_implode(string, array) would throw an error in core because it
checked for ArrayAccess instrad of CArray. CStrings implement
ArrayAccess but throw an UnsupportedOperationException on the keySet()
method. This has been fixed by changing the ArrayAccess check to a
CArray check.
